### PR TITLE
🌍 Rename book title to OpenCollaboration

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,4 +1,4 @@
-# The anatomy of collaboration - Code of Conduct
+# OpenCollaboration - Code of Conduct
 
 ## Our Pledge
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-A big welcome and thank you for considering contributing to **The anatomy of collaboration in software** ❤️
+A big welcome and thank you for considering contributing to **OpenCollaboration** ❤️
 
 Reading and following these guidelines will help us make the contribution process easy and effective for everyone involved. It also communicates that we agree to respect the time of the contributors managing and developing this open-source project.
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 </p>
 <br>
 
-The book *The anatomy of collaboration in software* presents a vertical slice of strategies that have proven useful for a broad spectrum of organizations. This brief literary excursion provides the foundation for building an autonomous, flexible, and collaborative environment at the core of our company.
+The book *OpenCollaboration* presents a vertical slice of strategies that have proven useful for a broad spectrum of organizations. This brief literary excursion provides the foundation for building an autonomous, flexible, and collaborative environment at the core of our company.
 
 ## Roadmap
 
-*The anatomy of collaboration in software* is under heavy development and undergoes continuous editing and restructuring. The main development currently focuses on polishing Part III. The additional roadmap for the v1 release currently looks as follows.
+*OpenCollaboration* is under heavy development and undergoes continuous editing and restructuring. The main development currently focuses on polishing Part III. The additional roadmap for the v1 release currently looks as follows.
 
 - [x] Introduction
 - [x] Part I (missing graphics)
@@ -20,7 +20,7 @@ The book *The anatomy of collaboration in software* presents a vertical slice of
 
 ## Running locally
 
-*The anatomy of collaboration in software* is written in Markdown and built to HTML via [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/). In order to start working locally, follow the instructions to [install Material for MkDocs](https://squidfunk.github.io/mkdocs-material/getting-started/).
+*OpenCollaboration* is written in Markdown and built to HTML via [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/). In order to start working locally, follow the instructions to [install Material for MkDocs](https://squidfunk.github.io/mkdocs-material/getting-started/).
 
 Once installed, we create and render a book using `mkdocs serve`. This command automatically detects and hot reloads changes to the Markdown source.
 
@@ -30,7 +30,7 @@ The [contribution guidelines](CONTRIBUTING.md) document strategies regarding pro
 
 ## Versioning
 
-*The anatomy of collaboration in software* follows the [semantic versioning](http://semver.org/) scheme.
+*OpenCollaboration* follows the [semantic versioning](http://semver.org/) scheme.
 
 - Patches include fixes to orthography, grammar, and punctuation.
 - Minor version bumps cover larger edits and new chapters.
@@ -38,7 +38,7 @@ The [contribution guidelines](CONTRIBUTING.md) document strategies regarding pro
 
 ## Licensing
 
-*The anatomy of collaboration in software* is licensed under the **CC-BY-4.0** license, please review the [LICENSE file](LICENSE) for further details.
+*OpenCollaboration* is licensed under the **CC-BY-4.0** license, please review the [LICENSE file](LICENSE) for further details.
 
 ## Built with ❤️ and
 

--- a/docs/book/introduction/README.md
+++ b/docs/book/introduction/README.md
@@ -1,17 +1,17 @@
 ---
 title: Introduction
-description: The anatomy of collaboration in software presents a vertical slice of strategies that have proven useful for a broad spectrum of organizations. This brief literary excursion provides the foundation for building an autonomous, flexible, and collaborative environment at the core of our company.
+description: OpenCollaboration presents a vertical slice of strategies that have proven useful for a broad spectrum of organizations. This brief literary excursion provides the foundation for building an autonomous, flexible, and collaborative environment at the core of our company.
 ---
 
 # Introduction
 
 Software companies are required to adapt to rapid technological, economical, and political change in order to viably compete on any market. This fact introduces the paradox of providing a stable and low-latency experience while continuously responding to user feedback and regulatory compliance.
 
-*The anatomy of collaboration in software* presents a vertical slice of strategies that have proven useful for a broad spectrum of organizations. This brief literary excursion provides the foundation for building an autonomous, flexible, and collaborative environment at the core of our company.
+*OpenCollaboration* presents a vertical slice of strategies that have proven useful for a broad spectrum of organizations. This brief literary excursion provides the foundation for building an autonomous, flexible, and collaborative environment at the core of our company.
 
 ## Structure
 
-*The anatomy of collaboration in software* is structured into three sections dealing with processes on different levels of our organization.
+*OpenCollaboration* is structured into three sections dealing with processes on different levels of our organization.
 
 - *The anatomy of a software company* covers how to optimally establish our teams and improve organic collaboration while limiting noise. We discuss established strategies of nurturing a growth mindset for sustainably increasing the complexity of our product, expanding the number of teams within our organization, and progress the professional expertise of our employees. The topics discussed in this section are solutions to problems encountered by technology officers and software architects.
 - *The anatomy of managing a team* frames supporting principles of leading a team. (WIP) This section covers day to day encounters of technical and team leads.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
 ---
-title: The anatomy of collaboration in software
+title: OpenCollaboration
 template: home.html
 ---

--- a/mkdocs-dist.yml
+++ b/mkdocs-dist.yml
@@ -1,6 +1,6 @@
 site_name: OpenCollaboration
 site_author: Daniel Lanner
-site_url: https://the-anatomy-of-collaboration.io/
+site_url: https://opencollaboration.io/
 site_description: >-
   OpenCollaboration presents a vertical slice of strategies 
   that have proven useful for a broad spectrum of organizations. This brief literary 

--- a/mkdocs-dist.yml
+++ b/mkdocs-dist.yml
@@ -1,8 +1,8 @@
-site_name: The anatomy of collaboration in software
+site_name: OpenCollaboration
 site_author: Daniel Lanner
 site_url: https://the-anatomy-of-collaboration.io/
 site_description: >-
-  The anatomy of collaboration in software presents a vertical slice of strategies 
+  OpenCollaboration presents a vertical slice of strategies 
   that have proven useful for a broad spectrum of organizations. This brief literary 
   excursion provides the foundation for building an autonomous, flexible, and 
   collaborative environment at the core of our company.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
-site_name: "[DEV] The anatomy of collaboration in software"
+site_name: "[DEV] OpenCollaboration"
 site_author: Daniel Lanner
 site_url: https://the-anatomy-of-collaboration.io/
 site_description: >-
-  The anatomy of collaboration in software presents a vertical slice of strategies 
+  OpenCollaboration presents a vertical slice of strategies 
   that have proven useful for a broad spectrum of organizations. This brief literary 
   excursion provides the foundation for building an autonomous, flexible, and 
   collaborative environment at the core of our company.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: "[DEV] OpenCollaboration"
 site_author: Daniel Lanner
-site_url: https://the-anatomy-of-collaboration.io/
+site_url: https://opencollaboration.io/
 site_description: >-
   OpenCollaboration presents a vertical slice of strategies 
   that have proven useful for a broad spectrum of organizations. This brief literary 

--- a/src/overrides/home.html
+++ b/src/overrides/home.html
@@ -28,7 +28,7 @@
   <div class="py-8 px-4 mx-auto max-w-screen-lg md:py-16">
       <div class="mb-24">
           <h1 class="text-book-night text-xl md:text-5xl font-extrabold mb-4 mt-1 mx-auto text-center">
-            The anatomy of collaboration
+            OpenCollaboration
           </h1>
           <p class="text-sm font-normal text-book-night mb-6 mx-auto max-w-screen-sm text-center">
             This book presents a vertical slice of strategies that have proven useful for a broad spectrum of organizations and provides the foundation for building autonomous, flexible, and collaborative environments.
@@ -49,7 +49,7 @@
             Scale with teams
           </h2>
           <p class="text-sm font-normal text-book-night mb-6">
-            Software companies are required to adapt to rapid technological, economical, and political change in order to viably compete on any market. The anatomy of collaboration discusses established strategies of nurturing a growth mindset for sustainably scaling the complexity of software products.
+            Software companies are required to adapt to rapid technological, economical, and political change in order to viably compete on any market. OpenCollaboration discusses established strategies of nurturing a growth mindset for sustainably scaling the complexity of software products.
           </p>
         </div>
         <div class="md:col-span-5 mb-8 md:mb-0">

--- a/src/overrides/home.html
+++ b/src/overrides/home.html
@@ -69,7 +69,7 @@
             Let's work on this together
         </h2>
         <p class="text-sm font-normal text-book-night mb-4">
-          The content of <i>The anatomy of collaboration in software</i> is available open source on GitHub.
+          The content of <i>OpenCollaboration</i> is available open source on GitHub.
           We believe in shared growth of knowledge and value contributions and edits from the community.
         </p>
         <a href="https://github.com/opencollabbook/book" class="text-book-robin-egg-blue hover:underline font-medium text-sm inline-flex items-center">


### PR DESCRIPTION
# Summary

Rename the book from "The anatomy of collaboration in software" (which is quite a mouthful) to "OpenCollaboration". The book is now available at opencollaboration.io.

- Update title across book
- Update title across documentation
- Update URL
- Update repo organization name
