### PR TITLE
🖊️ Indicate progress and consolidate spelling of chapters

### DIFF
--- a/docs/book/anatomy-of-a-code-change/README.md
+++ b/docs/book/anatomy-of-a-code-change/README.md
@@ -18,18 +18,18 @@ The current progress of this section:
 - [x] Planning implementations
 - [x] Trunk based development
 - [x] Commits
-- [ ] Pull Requests
-- [ ] Static Analysis
-- [ ] Code Reviews
+- [ ] Pull requests
+- [ ] Static analysis
+- [ ] Code reviews
 - [ ] Merging
 - [x] Testing
 - [ ] Documentation
-- [ ] Release Mechanisms
-- [ ] Artifact Management
-- [ ] Release Strategies
-- [ ] Repository Strategies
-- [ ] Infrastructure as Code
-- [ ] Monitoring and Observability
+- [ ] Release mechanisms
+- [ ] Artifact management
+- [ ] Release strategies
+- [ ] Repository strategies
+- [ ] Infrastructure as code
+- [ ] Monitoring and observability
 
 ## Version Control
 

--- a/docs/book/anatomy-of-a-code-change/README.md
+++ b/docs/book/anatomy-of-a-code-change/README.md
@@ -19,7 +19,7 @@ The current progress of this section:
 - [x] Trunk based development
 - [x] Commits
 - [ ] Pull Requests
-- [ ] Static Analyses
+- [ ] Static Analysis
 - [ ] Code Reviews
 - [ ] Merging
 - [x] Testing

--- a/docs/book/anatomy-of-a-code-change/cicd.md
+++ b/docs/book/anatomy-of-a-code-change/cicd.md
@@ -28,7 +28,7 @@ This offers verifiable and <!-- vale write-good.Weasel = NO -->timely<!-- vale w
 
 ## Continuous Deployment
 
-Continuous Deployment (CD) is an extension of continuous integration. After the static analyses has passed and the code changes have been integrated and we build the application and run automated integration tests.
+Continuous Deployment (CD) is an extension of continuous integration. After the static analysis has passed and the code changes have been integrated and we build the application and run automated integration tests.
 
 As the CI tests changes to our source code, CD tests the changes to our compiled machine code. If all tests pass we are certain to have a functioning package of our application. These packages are now staged for testing. Typical deployment testing can consist of one or more of the following mechanisms:
 

--- a/docs/book/anatomy-of-a-code-change/iac.md
+++ b/docs/book/anatomy-of-a-code-change/iac.md
@@ -10,6 +10,6 @@ Snowflake servers have gotten their current configuration by a combination of ma
 
 Versioning of IaC configs
 
-Tests, static analyses, pull requests
+Tests, static analysis, pull requests
 All versions can be restored to any time we would need it from the past
 

--- a/docs/book/anatomy-of-a-code-change/pr.md
+++ b/docs/book/anatomy-of-a-code-change/pr.md
@@ -37,9 +37,9 @@ Provide context why a particular constrain exists to make it feel less arbitrary
 
 Identify opportunities for automation in the pull request process, such as code linting, testing, and code coverage analysis.
 
-Opposed to tests that analyse code execution, static analyses reviews the syntax of the typed code.
+Opposed to tests that analyze code execution, static analysis reviews the syntax of the typed code.
 
-**Static Analysis** verifies good practices of the implementation. It scores HOW the engineer structured their implementation. Use automated code quality checks, such as code linting and style checks, to ensure that the code meets the required standards. We talk about the intricacies of static analyses in the [static analyses chapter]().
+**Static Analysis** verifies good practices of the implementation. It scores HOW the engineer structured their implementation. Use automated code quality checks, such as code linting and style checks, to ensure that the code meets the required standards. We talk about the intricacies of static analysis in the [static analysis chapter]().
 
 **Lightweight Tests** verify the acceptance criteria of the implementation and check that the engineer has not unintentially introduced new bugs or regressions. We talk about the intricacies of testing strategies in the [testing chapter]().
 

--- a/docs/book/anatomy-of-a-code-change/static-analysis.md
+++ b/docs/book/anatomy-of-a-code-change/static-analysis.md
@@ -1,6 +1,6 @@
 # Static analysis
 
-Upon creating PR's you may want to verify good practices of the implementation. Static analyses refers to tooling that checks the submitted code in its raw state. Opposed to tests that analyse code execution, static analyses reviews the syntax of the typed code.
+Upon creating PR's you may want to verify good practices of the implementation. Static analysis refers to tooling that checks the submitted code in its raw state. Opposed to tests that analyze code execution, static analysis reviews the syntax of the typed code.
 
 This step verifies that the engineer followed agreed upon processes on how to achieve the required features.
 

--- a/docs/book/anatomy-of-a-software-company/README.md
+++ b/docs/book/anatomy-of-a-software-company/README.md
@@ -11,11 +11,11 @@ The content within this book is what we have found most useful across a broad ra
 
 The current progress of this section:
 
-- [x] An Enabling Organization
+- [x] An enabling organization
 - [x] Autonomous team structure
-- [x] Internal Supporting Teams
-- [x] Communication Channels
-- [x] Team Interactions
+- [x] Internal supporting teams
+- [x] Communication channels
+- [x] Team interactions
 - [x] Standardization
 - [x] Innersourcing
-- [x] Team Education and Training
+- [x] Team education and training

--- a/docs/book/anatomy-of-managing-a-team/README.md
+++ b/docs/book/anatomy-of-managing-a-team/README.md
@@ -7,7 +7,7 @@ This part discusses the responsibilities of team and tech leads, common pitfalls
 
 The current progress of this section:
 
-- [ ] Culture, Diversity, and Language
+- [ ] Culture, diversity, and language
 - [ ] Leading by serving
 - [ ] Managing individual needs of team members
 - [ ] Building professional trust within a team

--- a/docs/book/introduction/README.md
+++ b/docs/book/introduction/README.md
@@ -15,7 +15,7 @@ Software companies are required to adapt to rapid technological, economical, and
 
 - *The anatomy of a software company* covers how to optimally establish our teams and improve organic collaboration while limiting noise. We discuss established strategies of nurturing a growth mindset for sustainably increasing the complexity of our product, expanding the number of teams within our organization, and progress the professional expertise of our employees. The topics discussed in this section are solutions to problems encountered by technology officers and software architects.
 - *The anatomy of managing a team* frames supporting principles of leading a team. This section covers day to day encounters of technical and team leads.
-- *The anatomy of a code change* analyses good practices for day to day work of engineers to achieve software products with high adaptability and stability. This section presents workflows and automation concepts to increase the frequencies of our software deliveries. These solutions are the foundation of sustainable growth and are applied by engineers across all levels.
+- *The anatomy of a code change* analyzes good practices for day to day work of engineers to achieve software products with high adaptability and stability. This section presents workflows and automation concepts to increase the frequencies of our software deliveries. These solutions are the foundation of sustainable growth and are applied by engineers across all levels.
 
 While the structure of this book does follow the reciprocal typical career progression of an engineer, we encourage all readers to glance at every section. Certain sociotechnical dependencies become more visible when digesting the entire book.
 

--- a/docs/book/introduction/README.md
+++ b/docs/book/introduction/README.md
@@ -14,7 +14,7 @@ Software companies are required to adapt to rapid technological, economical, and
 *OpenCollaboration* is structured into three sections dealing with processes on different levels of our organization.
 
 - *The anatomy of a software company* covers how to optimally establish our teams and improve organic collaboration while limiting noise. We discuss established strategies of nurturing a growth mindset for sustainably increasing the complexity of our product, expanding the number of teams within our organization, and progress the professional expertise of our employees. The topics discussed in this section are solutions to problems encountered by technology officers and software architects.
-- *The anatomy of managing a team* frames supporting principles of leading a team. (WIP) This section covers day to day encounters of technical and team leads.
+- *The anatomy of managing a team* frames supporting principles of leading a team. This section covers day to day encounters of technical and team leads.
 - *The anatomy of a code change* analyses good practices for day to day work of engineers to achieve software products with high adaptability and stability. This section presents workflows and automation concepts to increase the frequencies of our software deliveries. These solutions are the foundation of sustainable growth and are applied by engineers across all levels.
 
 While the structure of this book does follow the reciprocal typical career progression of an engineer, we encourage all readers to glance at every section. Certain sociotechnical dependencies become more visible when digesting the entire book.
@@ -44,3 +44,28 @@ We avoid the term "best practices" in this book. "Best" is subject to industries
 The concepts discussed in this book should be applied by implementing small changes for a limited number of teams. We reduce the cost and risk of verifying the positive effect we intend to implement in our organization by testing the changes within an isolated team.
 
 Lastly, while we do our best to keep the language as inclusive as possible there is a non-zero chance that certain words or phrases will not be received in the way they were meant to be. Language is difficult. The written word is difficult. Please read this book with the positive intent that it was penned in.
+
+## Current progress
+
+We are hard at work on *The anatomy of a code change* and are releasing new chapters periodically. A breakdown of our progress with a detailed list of chapters is available on the individual section pages.
+
+- [x] Introduction
+    - [x] Notes and structure
+    - [x] First draft
+    - [x] Polish
+    - [ ] Edit for v1.0.0
+- [x] [The anatomy of a software company](../anatomy-of-a-software-company/README.md)
+    - [x] Notes and structure
+    - [x] First draft
+    - [x] Polish
+    - [ ] Edit for v1.0.0
+- [ ] [The anatomy of managing a team](../anatomy-of-managing-a-team/README.md)
+    - [ ] Notes and structure
+    - [ ] First draft
+    - [ ] Polish
+    - [ ] Edit for v1.0.0
+- [ ] [The anatomy of a code change](../anatomy-of-a-code-change/README.md)
+    - [x] Notes and structure
+    - [ ] First draft
+    - [ ] Polish
+    - [ ] Edit for v1.0.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,7 +101,7 @@ nav:
       - Trunk Based Development: './book/anatomy-of-a-code-change/trunk-based-development.md'
       - Commits: './book/anatomy-of-a-code-change/commits.md'
       - Pull Requests: './book/anatomy-of-a-code-change/pr.md'
-      - Static Analyses: './book/anatomy-of-a-code-change/static-analyses.md'
+      - Static Analysis: './book/anatomy-of-a-code-change/static-analysis.md'
       - Code Reviews: './book/anatomy-of-a-code-change/code-review.md'
 
       - Merging:


### PR DESCRIPTION
# Summary

- Add the progress breakdown to *Introduction*
- Fix book wide spelling of "static analysis" and consolidate to American "to analyze"
- Consolidate lower case spelling of chapter names in table of content progress lists
